### PR TITLE
Modification to url structure of default language site

### DIFF
--- a/lib/jekyll/gettext/plugin.rb
+++ b/lib/jekyll/gettext/plugin.rb
@@ -67,7 +67,11 @@ module Jekyll
     end
     
     def url
-      "/" + language + super
+        unless language == site.config["default_language"]
+            "/" + language + super
+        else
+            "/"
+        end
     end
   end
 


### PR DESCRIPTION
Adds a conditional statement to plugin.rb that checks if default_language has been set in the config file. If it has, the default language site url is formed at the root directory instead of inside a language subfolder.

To use, add the following to your config file:
`default_language: "en"`
_change "en" to whatever the default language of the site_